### PR TITLE
Add fix so this will work in a wrapper cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Should match the archive you place in files/default - see `Usage` below.
 * `node['opendj']['install_dir']` - Where to unpack the software. Defaults
 to `/opt`
 
+* `node['opendj']['cookbook_source']` - Where to find the OpenDJ zip files if you use a wrapper cookbook. Defaults to `opendj`
+
 * `node['opendj']['dsml_enabled']` - Whether to enable the DSML gateway. 
 Defaults to true.  If set, you will also need the Tomcat recipe and to place
 a copy of the DSML gateway war file in the files_default directory - see

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,7 @@
 
 default["opendj"]["version"] = "2.5.0-Xpress1"
 default["opendj"]["install_dir"] = "/opt"
+default["opendj"]["cookbook_source"] = "opendj"
 default["opendj"]["installer_archive"] = default["opendj"]["install_dir"] + "/OpenDJ-" + default["opendj"]["version"] + ".zip"
 default["opendj"]["dsml_enabled"] = true
 default["opendj"]["dsml_war"] = "OpenDJ-" + default["opendj"]["version"] + "-DSML.war"

--- a/metadata.json
+++ b/metadata.json
@@ -5,23 +5,6 @@
   "maintainer": "Elliot Kendall",
   "maintainer_email": "elliot.kendall@ucsf.edu",
   "license": "BSD",
-  "platforms": {
-    "redhat": [
-
-    ],
-    "centos": [
-
-    ],
-    "fedora": [
-
-    ],
-    "ubuntu": [
-
-    ],
-    "debian": [
-
-    ]
-  },
   "dependencies": {
   },
   "recommendations": {

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,6 +8,7 @@ directory "#{node['opendj']['install_dir']}" do
 end
 
 cookbook_file "#{node['opendj']['installer_archive']}" do
+  cookbook node['opendj']['cookbook_source']
   mode "0644"
 end
 


### PR DESCRIPTION
I use wrapper cookbooks and would like to put my OpenDJ files in it's files/default, not in the opendj cookbook's files/default.

Also pulling out "platforms" from the metadata.json file.  Not sure why but Berkshelf/Ridley doesn't like it.  I posted the error I was getting in Issue #2 
