### PR TITLE
migrating to opendj 2.6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,13 +3,13 @@
 # Attributes:: default
 #
 
-default["opendj"]["version"] = "2.5.0-Xpress1"
+default["opendj"]["version"] = "2.6.0"
 default["opendj"]["install_dir"] = "/opt"
 default["opendj"]["cookbook_source"] = "opendj"
 default["opendj"]["installer_archive"] = default["opendj"]["install_dir"] + "/OpenDJ-" + default["opendj"]["version"] + ".zip"
 default["opendj"]["dsml_enabled"] = true
 default["opendj"]["dsml_war"] = "OpenDJ-" + default["opendj"]["version"] + "-DSML.war"
-default["opendj"]["home"] = default["opendj"]["install_dir"] + "/OpenDJ-" + default["opendj"]["version"]
+default["opendj"]["home"] = default["opendj"]["install_dir"] + "/opendj"
 
 default["opendj"]["sync_enabled"] = false
 default["opendj"]["sync_user"] = "ldapsync"

--- a/metadata.json
+++ b/metadata.json
@@ -24,5 +24,5 @@
   "recipes": {
     "opendj": "Installs OpenDJ LDAP server"
   },
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,8 @@ maintainer        "Elliot Kendall"
 maintainer_email  "elliot.kendall@ucsf.edu"
 license           "Apache 2.0"
 description       "Installs OpenDJ LDAP server"
-version           "0.1.1"
+version           "0.1.2"
+name              "opendj"
 
 recipe "opendj", "Installs OpenDJ LDAP server"
 

--- a/providers/postinstallconfig.rb
+++ b/providers/postinstallconfig.rb
@@ -13,28 +13,43 @@ action :run do
     mode "0644"
   end
 
-  cacerts = ""
-  node['opendj']['ssl_chain'].each do |cert|
-    cookbook_file "#{node['opendj']['home']}/certs/#{cert}" do
-      owner "#{node['opendj']['user']}"
-      mode "0644"
+  if node['opendj']['ssl_chain'].empty? then
+    script "create_keystore" do
+      interpreter "bash"
+      cwd "#{node['opendj']['home']}/certs"
+      user "#{node['opendj']['user']}"
+      code <<-EOH
+        openssl pkcs12 -export \
+         -inkey #{node['opendj']['ssl_key']} \
+         -in #{node['opendj']['ssl_cert']} \
+         -password pass:#{node['opendj']['keystore_pass']} \
+         -out keystore.p12
+      EOH
     end
-    cacerts = cacerts + "#{cert} "
-  end
-  script "create_keystore" do
-    interpreter "bash"
-    cwd "#{node['opendj']['home']}/certs"
-    user "#{node['opendj']['user']}"
-    code <<-EOH
-      cat #{cacerts} > cacerts.pem
-      openssl pkcs12 -export \
-       -inkey #{node['opendj']['ssl_key']} \
-       -in #{node['opendj']['ssl_cert']} \
-       -chain \
-       -CAfile cacerts.pem \
-       -password pass:#{node['opendj']['keystore_pass']} \
-       -out keystore.p12
-    EOH
+  else
+    cacerts = ""
+    node['opendj']['ssl_chain'].each do |cert|
+      cookbook_file "#{node['opendj']['home']}/certs/#{cert}" do
+        owner "#{node['opendj']['user']}"
+        mode "0644"
+      end
+      cacerts = cacerts + "#{cert} "
+    end
+    script "create_keystore" do
+      interpreter "bash"
+      cwd "#{node['opendj']['home']}/certs"
+      user "#{node['opendj']['user']}"
+      code <<-EOH
+        cat #{cacerts} > cacerts.pem
+        openssl pkcs12 -export \
+         -inkey #{node['opendj']['ssl_key']} \
+         -in #{node['opendj']['ssl_cert']} \
+         -chain \
+         -CAfile cacerts.pem \
+         -password pass:#{node['opendj']['keystore_pass']} \
+         -out keystore.p12
+      EOH
+    end
   end
 
   script "install_opendj" do

--- a/providers/postinstallconfig.rb
+++ b/providers/postinstallconfig.rb
@@ -42,7 +42,7 @@ action :run do
     cwd "#{node['opendj']['home']}"
     user "#{node['opendj']['user']}"
     code <<-EOH
-      ./setup --cli --no-prompt --addBaseEntry --enableStartTLS \
+      ./setup --cli --acceptLicense --no-prompt --addBaseEntry --enableStartTLS \
         --doNotStart \
         --usePkcs12Keystore #{node['opendj']['home']}/certs/keystore.p12 \
         --keyStorePassword #{node["opendj"]["keystore_pass"]} \

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,12 +34,14 @@ opendj_postinstallconfig "default" do
   subscribes :run, resources("script[unpack_archive]"), :immediately
 end
 
-cookbook_file "#{node['opendj']['home']}/dsml.war" do
-  source "#{node['opendj']['dsml_war']}"
-  mode "0644"
-end
+
 
 if node['opendj']['dsml_enabled']
+  cookbook_file "#{node['opendj']['home']}/dsml.war" do
+    source "#{node['opendj']['dsml_war']}"
+    mode "0644"
+  end
+  
   template "#{node['tomcat']['config_dir']}/Catalina/localhost/dsml.xml" do
     source "dsml.xml.erb"
     mode 0644


### PR DESCRIPTION
Hi,

I've created a patch with 3 fixes:
- when running setup of opendj 2.6 it requires a flag for accepting license
- when DSML is disabled, the recipe require the dsml war files.
- when using self signed certificates, the chain is empty and the openssl is broken.
